### PR TITLE
TrainingContainer: Allow to customize HDF keys

### DIFF
--- a/pyiron_potentialfit/atomicrex/potential_factory.py
+++ b/pyiron_potentialfit/atomicrex/potential_factory.py
@@ -1209,9 +1209,9 @@ def read_eam_fs_file(filename):
             f.readline()
             elements[element]["F"] = np.fromfile(f, count=Nrho, sep=" ")
             for rho_element in elements:
-                elements[element][
-                    "rho_{}{}".format(element, rho_element)
-                ] = np.fromfile(f, count=Nr, sep=" ")
+                elements[element]["rho_{}{}".format(element, rho_element)] = (
+                    np.fromfile(f, count=Nr, sep=" ")
+                )
 
         # V_ij = V_ji so it is written only once in the file => avoid attempts to read it twice
         # with a list of elements where it has been read

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -566,9 +566,9 @@ class ARStructureContainer:
         atomic_forces_storage._per_chunk_arrays["tolerance"][
             0 : storage.num_chunks
         ] = 0.01
-        atomic_forces_storage._per_element_arrays[
-            "target_val"
-        ] = storage._per_element_arrays["forces"][0 : storage.num_elements]
+        atomic_forces_storage._per_element_arrays["target_val"] = (
+            storage._per_element_arrays["forces"][0 : storage.num_elements]
+        )
 
         if "atomic-energy" not in self.fit_properties:
             self.fit_properties["atomic-energy"] = FlattenedARScalarProperty(
@@ -599,9 +599,9 @@ class ARStructureContainer:
             * self._structures._per_chunk_arrays["length"]
         )
         storage.add_array(name="forces", shape=(3,), per="element")
-        storage._per_element_arrays["forces"][
-            0 : storage.num_elements
-        ] = self.fit_properties["atomic-forces"][val_str]
+        storage._per_element_arrays["forces"][0 : storage.num_elements] = (
+            self.fit_properties["atomic-forces"][val_str]
+        )
         return storage
 
     def get_training_data(self) -> TrainingStorage:

--- a/pyiron_potentialfit/atomistics/job/trainingcontainer.py
+++ b/pyiron_potentialfit/atomistics/job/trainingcontainer.py
@@ -366,27 +366,28 @@ class TrainingPlots(StructurePlots):
 
 
 _HDF_KEYS = {
-        "energy": "output/generic/energy_pot",
-        "forces": "output/generic/forces",
-        "stress": "output/generic/pressures",
-        "indices": "output/generic/indices",
-        "species": "input/structure/species",
-        "cell": "output/generic/cells",
-        "positions": "output/generic/positions",
-        "pbc": "input/structure/cell/pbc",
+    "energy": "output/generic/energy_pot",
+    "forces": "output/generic/forces",
+    "stress": "output/generic/pressures",
+    "indices": "output/generic/indices",
+    "species": "input/structure/species",
+    "cell": "output/generic/cells",
+    "positions": "output/generic/positions",
+    "pbc": "input/structure/cell/pbc",
 }
 
 _JOB_HDF_OVERLAY_KEYS = {
-        "Vasp": {
-            # For DFT one should use the smeared energy to obtain values
-            # consistent with the forces, but the default energy_pot of DFT
-            # jobs is the energy extrapolated to zero smearing
-            "energy": "output/generic/dft/energy_free",
-            # HACK: VASP work-around, current contents of pressures are meaningless, correct values are in
-            # output/generic/stresses
-            "stress": "output/generic/stresses",
-        }
+    "Vasp": {
+        # For DFT one should use the smeared energy to obtain values
+        # consistent with the forces, but the default energy_pot of DFT
+        # jobs is the energy extrapolated to zero smearing
+        "energy": "output/generic/dft/energy_free",
+        # HACK: VASP work-around, current contents of pressures are meaningless, correct values are in
+        # output/generic/stresses
+        "stress": "output/generic/stresses",
+    }
 }
+
 
 class TrainingStorage(StructureStorage):
     def __init__(self):
@@ -431,10 +432,11 @@ class TrainingStorage(StructureStorage):
             ]
         return self._table_cache
 
-    def include_job(self,
-                    job,
-                    iteration_step=-1,
-                    hdf_keys=None,
+    def include_job(
+        self,
+        job,
+        iteration_step=-1,
+        hdf_keys=None,
     ):
         """
         Add structure, energy, forces and pressures from an inspected or loaded job.

--- a/pyiron_potentialfit/atomistics/job/trainingcontainer.py
+++ b/pyiron_potentialfit/atomistics/job/trainingcontainer.py
@@ -365,6 +365,29 @@ class TrainingPlots(StructurePlots):
         plt.xlabel(r"Force [eV/$\mathrm{\AA}$]")
 
 
+_HDF_KEYS = {
+        "energy": "output/generic/energy_pot",
+        "forces": "output/generic/forces",
+        "stress": "output/generic/pressures",
+        "indices": "output/generic/indices",
+        "species": "input/structure/species",
+        "cell": "output/generic/cells",
+        "positions": "output/generic/positions",
+        "pbc": "input/structure/cell/pbc",
+}
+
+_JOB_HDF_OVERLAY_KEYS = {
+        "Vasp": {
+            # For DFT one should use the smeared energy to obtain values
+            # consistent with the forces, but the default energy_pot of DFT
+            # jobs is the energy extrapolated to zero smearing
+            "energy": "output/generic/dft/energy_free",
+            # HACK: VASP work-around, current contents of pressures are meaningless, correct values are in
+            # output/generic/stresses
+            "stress": "output/generic/stresses",
+        }
+}
+
 class TrainingStorage(StructureStorage):
     def __init__(self):
         super().__init__()
@@ -408,7 +431,11 @@ class TrainingStorage(StructureStorage):
             ]
         return self._table_cache
 
-    def include_job(self, job, iteration_step=-1):
+    def include_job(self,
+                    job,
+                    iteration_step=-1,
+                    hdf_keys=None,
+    ):
         """
         Add structure, energy, forces and pressures from an inspected or loaded job.
 
@@ -416,23 +443,48 @@ class TrainingStorage(StructureStorage):
 
         Forces and stresses are only added if present in the output.
 
+        The locations in the job HDF5 file from which the training data is read
+        can be customized by passing a dictionary as `hdf_keys`, where the
+        values must be paths inside the job HDF5 file.  The available keys are
+        given below together with their default values.
+
+        * `energy`: `output/generic/energy_pot`
+        * `forces`: `output/generic/forces`
+        * `stress`: `output/generic/pressures`
+        * `indices`: `output/generic/indices`
+        * `cell`: `output/generic/cells`
+        * `positions`: `output/generic/positions`
+        * `species`: `input/structure/species`
+        * `pbc`: `input/structure/cell/pbc`
+
+        Other keys are ignored.  All entries except `pbc` and `species` must
+        lead to arrays that can be indexed by `iteration_step`.
+
+        For `Vasp` jobs the defaults are changed like this
+
+        * `energy`: `output/generic/dft/energy_free`
+        * `stress`: `output/generic/stresses`
+
+        to ensure that by default energies, forces and stresses are consistent.
+
         Args:
             job (:class:`.JobPath`, :class:`.AtomisticGenericJob`): job (path) to take structure from
             iteration_step (int, optional): if job has multiple steps, this selects which to add
+            hdf_keys (dict of str): customize where values are read from the
+                                    job HDF5 file
         """
 
+        hdf_keys = _HDF_KEYS.copy()
+        hdf_keys.update(_JOB_HDF_OVERLAY_KEYS.get(job["NAME"], {}))
+
         kwargs = {
-            "energy": job["output/generic/energy_pot"][iteration_step],
+            "energy": job[hdf_keys["energy"]][iteration_step],
         }
-        ff = job["output/generic/forces"]
+        ff = job[hdf_keys["forces"]]
         if ff is not None:
             kwargs["forces"] = ff[iteration_step]
 
-        # HACK: VASP work-around, current contents of pressures are meaningless, correct values are in
-        # output/generic/stresses
-        pp = job["output/generic/stresses"]
-        if pp is None:
-            pp = job["output/generic/pressures"]
+        pp = job[hdf_keys["stress"]]
         if pp is not None and len(pp) > 0:
             stress = np.asarray(pp[iteration_step])
             if stress.shape == (3, 3):
@@ -448,15 +500,17 @@ class TrainingStorage(StructureStorage):
                 )
             kwargs["stress"] = stress
 
-        ii = job["output/generic/indices"]
+        ii = job[hdf_keys["indices"]]
         if ii is not None:
             indices = ii[iteration_step]
         else:
+            # not all jobs save indices again in the output, but all atomistic
+            # jobs do it in the input
             indices = job["input/structure/indices"]
-        species = np.asarray(job["input/structure/species"])
-        cell = job["output/generic/cells"][iteration_step]
-        positions = job["output/generic/positions"][iteration_step]
-        pbc = job["input/structure/cell/pbc"]
+        species = np.asarray(job[hdf_keys["species"]])
+        cell = job[hdf_keys["cell"]][iteration_step]
+        positions = job[hdf_keys["positions"]][iteration_step]
+        pbc = job[hdf_keys["pbc"]]
 
         self.add_chunk(
             len(indices),

--- a/pyiron_potentialfit/fitsnap/common.py
+++ b/pyiron_potentialfit/fitsnap/common.py
@@ -1,6 +1,7 @@
 import numpy as np
 from fitsnap3lib.scrapers.ase_funcs import get_apre, create_shared_arrays
 
+
 def calc_bispectrum_names(twojmax):
     lst = []
     for j1 in range(0, twojmax + 1):
@@ -9,6 +10,7 @@ def calc_bispectrum_names(twojmax):
                 if j >= j1:
                     lst.append([j1 / 2.0, j2 / 2.0, j / 2.0])
     return lst
+
 
 def ase_scraper(
     s, frames, energies, forces, stresses=[[0, 0, 0], [0, 0, 0], [0, 0, 0]]

--- a/pyiron_potentialfit/meamfit/meamfit.py
+++ b/pyiron_potentialfit/meamfit/meamfit.py
@@ -310,16 +310,16 @@ class MeamFit(GenericJob):
         super(MeamFit, self).to_hdf(hdf=hdf, group_name=group_name)
         with self.project_hdf5.open("input") as hdf5_input:
             self.input.to_hdf(hdf5_input)
-            hdf5_input[
-                "calculation"
-            ] = self._calculation_dataframe.reset_index().to_dict(orient="list")
+            hdf5_input["calculation"] = (
+                self._calculation_dataframe.reset_index().to_dict(orient="list")
+            )
         with self.project_hdf5.open("output") as hdf5_output:
             hdf5_output["performance"] = self._potential_performance_dataframe.to_dict(
                 orient="list"
             )
-            hdf5_output[
-                "timings"
-            ] = self._potential_timings_dataframe.reset_index().to_dict(orient="list")
+            hdf5_output["timings"] = (
+                self._potential_timings_dataframe.reset_index().to_dict(orient="list")
+            )
 
     def from_hdf(self, hdf=None, group_name=None):
         super(MeamFit, self).from_hdf(hdf=hdf, group_name=group_name)

--- a/pyiron_potentialfit/runner/storageclasses.py
+++ b/pyiron_potentialfit/runner/storageclasses.py
@@ -214,9 +214,7 @@ class RunneraseHDFMixin(HasHDF):
         for prop in self.runnerase_properties:
             hdf[f"{prop}"] = self.__dict__[prop]
 
-    def _from_hdf(
-        self, hdf: ProjectHDFio, version: Optional[str] = None
-    ) -> Union[
+    def _from_hdf(self, hdf: ProjectHDFio, version: Optional[str] = None) -> Union[
         RunnerSplitTrainTest,
         RunnerWeights,
         RunnerScaling,


### PR DESCRIPTION
Allows to change in the location from hdf file where training data is read from by TrainingContainer.include_job.

This also adds a Vasp specific work around to read the smeared energy from the file instead of the generic energy_pot (which is the sigma to zero extrapolated energy), which previously resulted in inconsistent energies and forces.

Replaces https://github.com/pyiron/pyiron_contrib/pull/885