### PR TITLE
Ensure Species entries are strings

### DIFF
--- a/pyiron_potentialfit/mlip/mlip.py
+++ b/pyiron_potentialfit/mlip/mlip.py
@@ -133,7 +133,7 @@ class Mlip(GenericJob, PotentialFit):
                     "Name": ["".join(elements)],
                     "Filename": [self.potential_files],
                     "Model": ["Custom"],
-                    "Species": [elements],
+                    "Species": [list(map(str, elements))],
                     "Config": [["pair_style mlip mlip.ini\n", "pair_coeff * *\n"]],
                 }
             )


### PR DESCRIPTION
Since they come from a numpy array before, they are actually numpy.str_ which does not always play nice with third packages.