### PR TITLE
Atomixrex-xml-instead-of-poscar

### DIFF
--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -877,7 +877,7 @@ def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols
             xmlf.set("z", f"{f[2]}")
             idx+=1
 
-    return pbc, cell
+    return struct_xml
 
 
 def predefined_structure_xml(

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -877,10 +877,11 @@ def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols
         idx = 0
         xmlforces = ET.SubElement(struct_xml, 'atomic-forces')
         for f in forces:
-            xmlf = ET.SubElement(xmlatoms, "force")
+            xmlf = ET.SubElement(xmlforces, "force")
             xmlf.set("x", f"{f[0]}")
             xmlf.set("y", f"{f[1]}")
             xmlf.set("z", f"{f[2]}")
+            idx+=1
 
     return pbc, cell
 

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -525,7 +525,6 @@ class ARStructureContainer:
                     cell=self._structures.cell[i],
                     clamp=self._structures._per_chunk_arrays["clamp"][i],
                     fit_properties=fit_properties_xml,
-                    struct_file_path=self.structure_file_path,
                     fit=self._structures._per_chunk_arrays["fit"][i],
                 )
 

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -846,10 +846,10 @@ def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols
         mod_poscar=False,
     )
 
-    pbc = ET.SubElement(struct_xml, "pbc")
-    pbc.set("x", f"{pbc[0]}".lower())
-    pbc.set("y", f"{pbc[1]}".lower())
-    pbc.set("z", f"{pbc[2]}".lower())
+    xmlpbc = ET.SubElement(struct_xml, "pbc")
+    xmlpbc.set("x", f"{pbc[0]}".lower())
+    xmlpbc.set("y", f"{pbc[1]}".lower())
+    xmlpbc.set("z", f"{pbc[2]}".lower())
 
     xmlcell = ET.SubElement(struct_xml, "cell")
     for i in range(3):

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -875,7 +875,7 @@ def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols
             xmlf.set("x", f"{f[0]}")
             xmlf.set("y", f"{f[1]}")
             xmlf.set("z", f"{f[2]}")
-            xmlf.set("i", f"{f[idx]}")
+            xmlf.set("i", f"{idx}")
             idx+=1
 
     return struct_xml

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -404,10 +404,14 @@ class ARStructureContainer:
                 "Structure identifiers must not contain '/'. "
                 "Use .structure_file_path to use existing POSCAR files"
             )
-        
-    def write_xml_with_poscars(self, directory, name="structures.xml",):
+
+    def write_xml_with_poscars(
+        self,
+        directory,
+        name="structures.xml",
+    ):
         """
-        Internal helper function that writes an atomicrex structure input 
+        Internal helper function that writes an atomicrex structure input
         with POSCAR format structures. Not recommended normally.
 
         Args:
@@ -486,7 +490,7 @@ class ARStructureContainer:
             root.append(struct_xml)
         filename = posixpath.join(directory, name)
         write_pretty_xml(root, filename)
-    
+
     def write_xml_file(self, directory, name="structures.xml", use_poscars=False):
         """
         Internal helper function that writes an atomicrex style
@@ -506,7 +510,7 @@ class ARStructureContainer:
                 for prop, flat_prop in self.fit_properties.items():
                     if not prop in ("lattice-parameter", "ca-ratio"):
                         fit_properties_xml.append(flat_prop.to_xml_element(i, prop))
-                
+
                 vec_start = self._structures.start_index[i]
                 vec_end = self._structures.start_index[i] + self._structures.length[i]
                 forces = self.fit_properties["atomic-forces"]._per_element_arrays[
@@ -547,13 +551,10 @@ class ARStructureContainer:
                     fit_properties=fit_properties_xml,
                     fit=self._structures._per_chunk_arrays["fit"][i],
                 )
-                
+
             root.append(struct_xml)
         filename = posixpath.join(directory, name)
         write_pretty_xml(root, filename)
-
-
-
 
     def _parse_final_properties(self, struct_lines):
         """
@@ -821,7 +822,6 @@ def structure_meta_xml(
         else:
             poscar_file.text = f"{struct_file_path}POSCAR_{identifier}"
 
-
     if not clamp:
         relax_dof = ET.SubElement(struct_xml, "relax-dof")
         atom_coordinates = ET.SubElement(relax_dof, "atom-coordinates")
@@ -835,7 +835,18 @@ def structure_meta_xml(
     return struct_xml
 
 
-def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols, forces=None, fit=True,relative_weight=1, clamp=True,):
+def user_structure_xml(
+    identifier,
+    fit_properties,
+    pbc,
+    cell,
+    positions,
+    symbols,
+    forces=None,
+    fit=True,
+    relative_weight=1,
+    clamp=True,
+):
 
     struct_xml = structure_meta_xml(
         identifier=identifier,
@@ -869,14 +880,14 @@ def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols
 
     if forces is not None:
         idx = 0
-        xmlforces = ET.SubElement(struct_xml, 'atomic-forces')
+        xmlforces = ET.SubElement(struct_xml, "atomic-forces")
         for f in forces:
             xmlf = ET.SubElement(xmlforces, "force")
             xmlf.set("x", f"{f[0]}")
             xmlf.set("y", f"{f[1]}")
             xmlf.set("z", f"{f[2]}")
             xmlf.set("i", f"{idx}")
-            idx+=1
+            idx += 1
 
     return struct_xml
 

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -783,8 +783,8 @@ def structure_meta_xml(
     relative_weight,
     clamp,  ## Not sure if and how this combines with relax in the ARFitParameter sets
     fit_properties,
-    struct_file_path,
-    fit,
+    struct_file_path=None,
+    fit=True,
     mod_poscar=True,
 ):
     """
@@ -820,12 +820,7 @@ def structure_meta_xml(
             poscar_file.text = f"POSCAR_{identifier}"
         else:
             poscar_file.text = f"{struct_file_path}POSCAR_{identifier}"
-    else:
-        #    struct_xml.extend(structure_to_xml_element(structure))
-        raise NotImplementedError(
-            "Only writing structure meta information, \n"
-            "not structure data for now because this is not implemented in atomicrex"
-        )
+
 
     if not clamp:
         relax_dof = ET.SubElement(struct_xml, "relax-dof")

--- a/pyiron_potentialfit/atomicrex/structure_list.py
+++ b/pyiron_potentialfit/atomicrex/structure_list.py
@@ -875,6 +875,7 @@ def user_structure_xml(identifier, fit_properties, pbc, cell, positions, symbols
             xmlf.set("x", f"{f[0]}")
             xmlf.set("y", f"{f[1]}")
             xmlf.set("z", f"{f[2]}")
+            xmlf.set("i", f"{f[idx]}")
             idx+=1
 
     return struct_xml


### PR DESCRIPTION
Sets target forces directly in structure XML instead of using modified POSCARs. This allows to use structures with arbitrary order of species.
Requires https://gitlab.com/atomicrex/atomicrex/-/merge_requests/51 to work.