### PR TITLE
Compress Pacemaker jobs

### DIFF
--- a/pyiron_potentialfit/pacemaker/job.py
+++ b/pyiron_potentialfit/pacemaker/job.py
@@ -43,6 +43,7 @@ class PacemakerJob(GenericJob, PotentialFit):
         self.__version__ = "0.2"
 
         self._train_job_id_list = []
+        self._compress_by_default = True
 
         self.input = GenericParameters(table_name="input")
         self._cutoff = 7.0


### PR DESCRIPTION
A single pacemaker job creates 26 files by default, when the working directory is not compressed. This pull request adds compression to the pacemaker jobs by default. 

Initially reported by @HaithamGaafer 