### PR TITLE
Overwrote compress function to exclude 'output_potential.yace'

### DIFF
--- a/pyiron_potentialfit/pacemaker/job.py
+++ b/pyiron_potentialfit/pacemaker/job.py
@@ -43,7 +43,7 @@ class PacemakerJob(GenericJob, PotentialFit):
         self.__version__ = "0.2"
 
         self._train_job_id_list = []
-
+        self._compress_by_default = True
         self.input = GenericParameters(table_name="input")
         self._cutoff = 7.0
         self.input["cutoff"] = self._cutoff
@@ -455,3 +455,14 @@ class PacemakerJob(GenericJob, PotentialFit):
         total_training_df.reset_index(drop=True, inplace=True)
 
         return total_training_df
+    
+    def compress(self, files_to_compress=None):
+        """
+        Compress the output files of a job object.
+
+        Args:
+            files_to_compress (list): A list of files to compress (optional)
+        """
+        if files_to_compress is None:
+            files_to_compress = [f for f in self.files.list() if f != 'output_potential.yace']
+        super(PacemakerJob, self).compress(files_to_compress=files_to_compress)


### PR DESCRIPTION
The compress function is added to compress the files excluding the 'output_potential.yace' file which is necessary for the LAMMPS potential