### PR TITLE
Replace np.cast with numpy>=2 compatible alternative

### DIFF
--- a/pyiron_potentialfit/mlip/mlip.py
+++ b/pyiron_potentialfit/mlip/mlip.py
@@ -260,7 +260,7 @@ class Mlip(GenericJob, PotentialFit):
         store.add_array("stress", dtype=np.float64, shape=(6,), per="chunk")
         for cfg in loadcfgs(os.path.join(self.working_directory, filename)):
             struct = Atoms(
-                symbols=species[np.cast[np.int64](cfg.types)],
+                symbols=species[np.asarray(cfg.types, dtype=np.int64)],
                 positions=cfg.pos,
                 cell=cfg.lat,
                 pbc=[True] * 3,


### PR DESCRIPTION
Seems to be the only place where np.cast was used.